### PR TITLE
Add full-text MIT license of Outstatic

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,31 @@
+# Credits
+
+This application uses code from other open-source projects. The copyright statements of these open-source projects are listed below.
+
+## Outstatic
+
+Source: <https://github.com/avitorio/outstatic>
+
+```markdown
+The MIT License (MIT)
+
+Copyright (c) 2023 Andre Vitorio - Outstatic.com.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```


### PR DESCRIPTION
Based on what I know about the MIT license (I am not a lawyer), it states

```
The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.
```

where the `above copyright notice` refers to this line `Copyright (c) 2023 Andre Vitorio - Outstatic.com.` specifically with the author's name, and `permission notice` refers to this bunch of paragraphs.

```markdown
Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
SOFTWARE.
```

So, by adding this complete copy of the MIT license, you would be in full compliance with the license requirements.

It may seem redundant and trivial given that this project is also under the MIT license, but for instance look at `about:license` on Firefox, you can see that every open-source dependency has its full license text (with the dependency's author's name and copyright year) displayed there (`about:license#vtune` is an MIT licensed dependency by Intel).

Once you have done so, the MIT license imposes no other restrictions on how you use the code, that you already know.

---

Sidenote, the MIT license does **not** require you to mention Outstatic in your marketing materials (like your README). If Outstatic's author wanted that, something like the [BSD-4-Clause](https://spdx.org/licenses/BSD-4-Clause.html) license should have been used instead.